### PR TITLE
Fix logic to extract file sha256 hashes

### DIFF
--- a/packages/service/test/integration/ofac.spec.ts
+++ b/packages/service/test/integration/ofac.spec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai'
+
+import dotenv from "dotenv"
+dotenv.config()
+process.env.DATASET_ID = 'testing'
+process.env.TABLE_ID = 'integration_blacklist'
+
+import ofac from '../../src/readers/ofac'
+
+describe('integration: ofac reader', async function () {
+
+    it('get checksum values', async function () {
+        const test = await ofac.getChecksumValues()
+
+        expect(test).to.not.be.null
+    })
+})


### PR DESCRIPTION
- The location of ofac's file checksum page changed
> `https://home.treasury.gov/policy-issues/financial-sanctions/specially-designated-nationals-list-sdn-list/hash-values-for-ofac-sanctions-list-files`
> to:
> `https://ofac.treasury.gov/specially-designated-nationals-list-sdn-list/hash-values-for-ofac-sanctions-list-files`
- The contents of the webpage also slightly changed meaning the code was no longer able to extract the checksum values required to ensure we're downloading the correct files (and content).